### PR TITLE
Added MQTT-C to "Networking and Internet"

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,7 @@ comprehensive and high-level, you may want the Web Frameworks section.
 * [lwan][199] - Experimental, scalable, high-performance HTTP
   server. [``GPL-2.0-only``][GPL-2.0-only]
 * [mongoose][171] - Embedded web server. [``GPL-2.0-only``][GPL-2.0-only]
+* [MQTT-C][549] - A portable MQTT C client for embedded systems and PCs alike. [``MIT``][MIT]
 * [nanomsg][139] - C-based implementation of ZeroMQ. [``MIT``][MIT]
 * [NNG][106] - nanomsg-next-generation - lightweight brokerless messaging.
   [``MIT``][MIT] 
@@ -1639,3 +1640,4 @@ support for C.
 [546]: https://scientificc.github.io/cmathl/
 [547]: https://github.com/benhoyt/inih
 [548]: https://github.com/libarchive/libarchive
+[549]: https://github.com/LiamBindle/MQTT-C


### PR DESCRIPTION
Added my MQTT-C client to the Networking and Internet subsection.

#### Some information on MQTT-C
MQTT-C is an MQTT v3.1.1 client written in C. MQTT is a lightweight publisher-subscriber-based messaging protocol that is commonly used in IoT and networking applications where high-latency and low data-rate links are expected. The purpose of MQTT-C is to provide a portable MQTT client, written in C, for embedded systems and PC's alike. MQTT-C does this by providing a transparent Platform Abstraction Layer (PAL) which makes porting to new platforms easy. MQTT-C is completely thread-safe but can also run perfectly fine on single-threaded systems making MQTT-C well-suited for embedded systems and microcontrollers. Finally, MQTT-C is small; there are only two source files totalling less than 2000 lines.

Cheers,

Liam