### PR TITLE
add json library

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,6 +831,7 @@ This includes libraries for things like XML, JSON, CSV, and other similar format
   Schema. [``LGPL-2.0-or-later``][LGPL-2.0-or-later] or
   [``LGPL-2.1-or-later``][LGPL-2.1-or-later] or [``LGPL-3.0-or-later``][LGPL-3.0-or-later]
 * [YAJL][60] - Fast streaming JSON parser library. [``ISC``][ISC]
+* [json][552] - 🔋 Very simple and very powerful JSON parser. [``MIT``][MIT]
 
 ### INI ###
 
@@ -1650,3 +1651,4 @@ support for C.
 [549]: https://github.com/LiamBindle/MQTT-C
 [550]: https://github.com/LeoVen/C-Macro-Collections
 [551]: https://github.com/mysql/mysql-server
+[552]: http://github.com/recp/json


### PR DESCRIPTION
Hi,

Just finished a JSON library to use it in my 3D importer (http://github.com/recp/AssetKit) which is in progress. 

The JSON parser doesn't alloc and copy JSON contents or create hash tables... It only allocs memory for data structure or tokens. It creates pointers by using existing JSON content. It may support pointers on file too in the future. 

As you may see that, it only has one source file and a few headers. In the future it will support both header-only library and compile option like (http://github.com/recp/cglm). It also does not use recursive way to build DOM-like tree which makes it very attractive. There are some header-only inline utility functions to make things easier.

Since this is new library, it will be more improved by time.

FWIW, I'll write new XML parser like this JSON parser asap.