### PR TITLE
Add Rogueutil, a header-only TUI library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1044,6 +1044,8 @@ A 'catch-all' category for anything that doesn't fit well anywhere else.
   [``BSD-3-Clause``][BSD-3-Clause]
 * [rabbitmq-c][228] - Client library for [RabbitMQ][229]. [``MIT``][MIT]
 * [Ragel][54] - DSL for state machines that compiles to C. [``GPL-2.0-only``][GPL-2.0-only]
+* [Rogueutil][565] - Cross-platform library for creating text-based user 
+  interfaces (TUI) [``Apache-2.0``][Apache-2.0]
 * [sort][190] - Collection of sorting routines, which type-specialize at
   compile-time with a user-defined type. [``MIT``][MIT]
 * [termbox][396] - Library for writing text-based interfaces. [``MIT``][MIT]
@@ -1682,3 +1684,4 @@ support for C.
 [562]: https://kristaps.bsd.lv/kcgi
 [563]: https://github.com/christophercrouzet/rexo
 [564]: https://github.com/ithewei/libhv
+[565]: https://github.com/sakhmatd/rogueutil


### PR DESCRIPTION
It's primarily a C library, since I don't write C++, but there is C++ compatibility left over from the original project that I didn't touch.

Let me know if you think it would fit better in [awesome-cpp](https://github.com/fffaraz/awesome-cpp).