### PR TITLE
add AssetKit, xml and cmt graphics library

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Engines, libraries and other helpful things specifically for making games.
   library. [``Zlib``][Zlib]
 * [cglm][542] - 📽 Optimized OpenGL/Graphics Math (glm) for C. [``MIT``][MIT]
 * [Chipmunk2D][303] - Fast and lightweight 2D game physics library. [``MIT``][MIT]
+* [cmt][569] - 🎮 C Bindings/Wrappers for Apple's METAL Graphics Framework. [``MIT``][MIT]
 * [Corange][101] - Game engine in pure C. [``BSD-2-Clause``][BSD-2-Clause]
 * [CSFML][90] - Binding for [SFML][91]. [``Zlib``][Zlib]
 * [Darkplaces][369] - Modified version of the Quake2 engine. [``GPL-2.0-only``][GPL-2.0-only]
@@ -419,6 +420,7 @@ Programmatic manipulation of graphics in C; if you want to make a GUI, the
 Graphical User Interface section has what you need.
 
 * [Cairo][384] - 2D graphics library. [``LGPL-2.1-only``][LGPL-2.1-only] or [``MPL-1.1``][385].
+* [cmt][569] - 🎮 C Bindings/Wrappers for Apple's METAL Graphics Framework. [``MIT``][MIT]
 * [giflib][401] - Library for reading and writing gif images. [``MIT``][MIT]
 * [graphene][515] - Thin layer of graphical data types. [``MIT``][MIT]
 * [heman][365] - Tiny library of image utilities dealing with height maps,
@@ -1693,3 +1695,4 @@ support for C.
 [566]: https://github.com/the-tcpdump-group/libpcap
 [567]: http://esbmc.org/
 [568]: https://github.com/recp/xml
+[569]: https://github.com/recp/cmt

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Engines, libraries and other helpful things specifically for making games.
 
 * [Allegro][48] - Cross-platform, video game development and multimedia
   library. [``Zlib``][Zlib]
+* [AssetKit][570] 🎨 3D asset importer/exporter/util library based on COLLADA/glTF specs [``MIT``][MIT]
 * [cglm][542] - 📽 Optimized OpenGL/Graphics Math (glm) for C. [``MIT``][MIT]
 * [Chipmunk2D][303] - Fast and lightweight 2D game physics library. [``MIT``][MIT]
 * [cmt][569] - 🎮 C Bindings/Wrappers for Apple's METAL Graphics Framework. [``MIT``][MIT]
@@ -419,6 +420,7 @@ Engines, libraries and other helpful things specifically for making games.
 Programmatic manipulation of graphics in C; if you want to make a GUI, the
 Graphical User Interface section has what you need.
 
+* [AssetKit][570] 🎨 3D asset importer/exporter/util library based on COLLADA/glTF specs [``MIT``][MIT]
 * [Cairo][384] - 2D graphics library. [``LGPL-2.1-only``][LGPL-2.1-only] or [``MPL-1.1``][385].
 * [cmt][569] - 🎮 C Bindings/Wrappers for Apple's METAL Graphics Framework. [``MIT``][MIT]
 * [giflib][401] - Library for reading and writing gif images. [``MIT``][MIT]
@@ -1696,3 +1698,4 @@ support for C.
 [567]: http://esbmc.org/
 [568]: https://github.com/recp/xml
 [569]: https://github.com/recp/cmt
+[570]: https://github.com/recp/AssetKit

--- a/README.md
+++ b/README.md
@@ -874,6 +874,7 @@ This includes libraries for things like XML, JSON, CSV, and other similar format
 
 * [Expat][89] - Stream-oriented XML parser. [MIT][MIT]
 * [libxml2][62] - Standards-compliant, portable XML parser. [MIT][MIT]
+* [xml][568] - Simple, low-memory-use XML parser / tokenizer. [``MIT``][MIT]
 
 ### YAML ###
 
@@ -1691,3 +1692,4 @@ support for C.
 [565]: https://github.com/sakhmatd/rogueutil
 [566]: https://github.com/the-tcpdump-group/libpcap
 [567]: http://esbmc.org/
+[568]: https://github.com/recp/xml


### PR DESCRIPTION
Hi,

Here a few good libraries to add the list.

## [AssetKit](https://github.com/recp/AssetKit)

I was working on 3D (maybe + 2D later) importer and util library written in pure 100% C. It is ready to be public. It can import glTF 2.0, COLLADA 1.4/1.41/1.5 files with single interface. Its size is very small e.g ~244KB + stb_image.h (160KB) == ~404KB. And it provides lot of options and utils to make loading and rendering stages flexible, fast as possible. In the future it may support additional formats to import and export.

## [xml](https://github.com/recp/xml)

To make AssetKit portable, make build fast and make parsing XML easy, I have dropped libxml2 and wrote new XML parser (and a JSON parser). I have used it in AssetKit to parse XMLs. 

The XML parser doesn't alloc and copy XML contents... It only allocs memory for data structure or tokens. It creates pointers by using existing XML content. It may support pointers on file too in the future.

* header-only or optional compiled library
* option to store members and arrays as reverse order or normal
* option to separate xml tag prefix
* doesn't alloc memory for keys and values only for tokens
* creates DOM-like data structure to make it easy to iterate though
* simple api
* provides some util functions to print xml, get int32, int64, float, double...
* very small library
* unique way to parse XML (check the object map section)
* helper to get string nodes, primitive values (int, float, bool) for both attribs and values

the parsing happens in single function so it must be very fast. In the future SIMD may be supported to make it fastest.

Related PR: https://github.com/kozross/awesome-c/pull/101

## [cmt](https://github.com/recp/cmt)

This is C wrappers for Apple's new graphics library/framework: https://developer.apple.com/metal

Because AFAIK Apple only provides Objective-C and Swift APIs for Metal. This is why I have wrote this library. C and C++ can use this library to bind their graphics-related softwares to Metal. 

Since this is written in C, any language can use this to access Metal. OpenGL is deprecated on Apple platforms e.g macOS, iOS, iPadOS...

## in progress: [gpu](https://github.com/recp/gpu) and [ui](https://github.com/recp/ui)

There is a GPU library which I'm working on: http://github.com/recp/gpu and ui library: https://github.com/recp/ui, I'll create a PR for them after finished. 
